### PR TITLE
don't close twice

### DIFF
--- a/src/main/scala/ai/lum/common/TryWithResources.scala
+++ b/src/main/scala/ai/lum/common/TryWithResources.scala
@@ -25,22 +25,48 @@ object TryWithResources {
 
   /** like java's try-with-resources */
   def using[A <: Closeable, B](resource: A)(f: A => B): B = {
+    var exception: Option[Throwable] = None
     try {
+      // try to call f() with the resource as argument
       f(resource)
     } catch {
-      case e1: Throwable =>
-        try {
-          resource.close()
-        } catch {
-          case NonFatal(e2) =>
-            e1.addSuppressed(e2)
-          case e2: Throwable =>
-            e2.addSuppressed(e1)
-            throw e2
-        }
-        throw e1
+      case e: Throwable =>
+        // if there is an exception
+        // then save it for later and rethrow it
+        exception = Some(e)
+        throw e
     } finally {
-      resource.close()
+      exception match {
+        case None =>
+          // if there was no exception
+          // then we can just close the resource
+          // and if there is an exception during closing
+          // we can just let it happen
+          resource.close()
+        case Some(e1) =>
+          // if there was an exception
+          // then we need to be more careful when closing the resource
+          try {
+            resource.close()
+          } catch {
+            case NonFatal(e2) =>
+              // if we get a nonfatal exception during closing
+              // then we need to suppress it
+              e1.addSuppressed(e2)
+            case e2: Throwable if NonFatal(e1) =>
+              // if we get a fatal exception during closing
+              // and the original exception wasn't fatal
+              // then we need to suppress the original exception
+              // and throw the new one
+              e2.addSuppressed(e1)
+              throw e2
+            case e2: Throwable =>
+              // if we get a fatal exception during closing
+              // and the original exception was fatal too
+              // then we suppress the new exception
+              e1.addSuppressed(e2)
+          }
+      }
     }
   }
 

--- a/src/test/scala/ai/lum/common/TestTryWithResources.scala
+++ b/src/test/scala/ai/lum/common/TestTryWithResources.scala
@@ -1,0 +1,113 @@
+package ai.lum.common
+
+import org.scalatest._
+import TryWithResources.using
+
+class TestTryWithResources extends FlatSpec with Matchers {
+
+  import TestTryWithResources._
+
+  "TryWithResources" should "not throw an exception" in {
+    noException should be thrownBy using (new Closeable) { c =>
+      c.doSomething()
+    }
+  }
+
+  it should "throw an exception" in {
+    val thrown = the [Exception] thrownBy using (new CloseableWithException) { c =>
+      c.doSomething()
+    }
+    thrown.getSuppressed() should have length (0)
+  }
+
+  it should "throw a fatal exception" in {
+    val thrown = the [InterruptedException] thrownBy using (new CloseableWithFatalException) { c =>
+      c.doSomething()
+    }
+    thrown.getSuppressed() should have length (0)
+  }
+
+  it should "throw an exception during closing" in {
+    val thrown = the [Exception] thrownBy using (new CloseableWithCloseException) { c =>
+      c.doSomething()
+    }
+    thrown.getSuppressed() should have length (0)
+  }
+
+  it should "throw a fatal exception during closing" in {
+    val thrown = the [Exception] thrownBy using (new CloseableWithCloseFatalException) { c =>
+      c.doSomething()
+    }
+    thrown.getSuppressed() should have length (0)
+  }
+
+  it should "suppress exception when closing fatal exception occurs" in {
+    val thrown = the [InterruptedException] thrownBy using (new CloseableWithExceptionAndCloseFatalException) { c =>
+      c.doSomething()
+    }
+    thrown.getSuppressed() should have length (1)
+  }
+
+  it should "suppress closing exception when fatal exception occurs" in {
+    val thrown = the [InterruptedException] thrownBy using (new CloseableWithExceptionAndCloseFatalException) { c =>
+      c.doSomething()
+    }
+    thrown.getSuppressed() should have length (1)
+  }
+
+}
+
+object TestTryWithResources {
+
+  class Closeable {
+    def close(): Unit = {}
+    def doSomething(): Unit = {}
+  }
+
+  class CloseableWithException {
+    def close(): Unit = {}
+    def doSomething(): Unit = {
+      throw new Exception
+    }
+  }
+
+  class CloseableWithFatalException {
+    def close(): Unit = {}
+    def doSomething(): Unit = {
+      throw new InterruptedException
+    }
+  }
+
+  class CloseableWithCloseException {
+    def close(): Unit = {
+      throw new Exception
+    }
+    def doSomething(): Unit = {}
+  }
+
+  class CloseableWithCloseFatalException {
+    def close(): Unit = {
+      throw new InterruptedException
+    }
+    def doSomething(): Unit = {}
+  }
+
+  class CloseableWithFatalExceptionAndCloseException {
+    def close(): Unit = {
+      throw new Exception
+    }
+    def doSomething(): Unit = {
+      throw new InterruptedException
+    }
+  }
+
+  class CloseableWithExceptionAndCloseFatalException {
+    def close(): Unit = {
+      throw new InterruptedException
+    }
+    def doSomething(): Unit = {
+      throw new Exception
+    }
+  }
+
+}

--- a/src/test/scala/ai/lum/common/TestTryWithResources.scala
+++ b/src/test/scala/ai/lum/common/TestTryWithResources.scala
@@ -8,51 +8,84 @@ class TestTryWithResources extends FlatSpec with Matchers {
   import TestTryWithResources._
 
   "TryWithResources" should "not throw an exception" in {
-    noException should be thrownBy using (new Closeable) { c =>
+    val closeable = new Closeable
+    noException should be thrownBy using (closeable) { c =>
       c.doSomething()
     }
+    closeable.n should be (1)
   }
 
   it should "throw an exception" in {
-    val thrown = the [Exception] thrownBy using (new CloseableWithException) { c =>
+    val closeable = new CloseableWithException
+    val thrown = the [Exception] thrownBy using (closeable) { c =>
       c.doSomething()
     }
+    thrown.getMessage() shouldEqual ("doSomething")
     thrown.getSuppressed() should have length (0)
+    closeable.n should be (1)
   }
 
   it should "throw a fatal exception" in {
-    val thrown = the [InterruptedException] thrownBy using (new CloseableWithFatalException) { c =>
+    val closeable = new CloseableWithFatalException
+    val thrown = the [InterruptedException] thrownBy using (closeable) { c =>
       c.doSomething()
     }
+    thrown.getMessage() shouldEqual ("doSomething")
     thrown.getSuppressed() should have length (0)
+    closeable.n should be (1)
   }
 
   it should "throw an exception during closing" in {
-    val thrown = the [Exception] thrownBy using (new CloseableWithCloseException) { c =>
+    val closeable = new CloseableWithCloseException
+    val thrown = the [Exception] thrownBy using (closeable) { c =>
       c.doSomething()
     }
+    thrown.getMessage() shouldEqual ("close")
     thrown.getSuppressed() should have length (0)
+    closeable.n should be (1)
   }
 
   it should "throw a fatal exception during closing" in {
-    val thrown = the [Exception] thrownBy using (new CloseableWithCloseFatalException) { c =>
+    val closeable = new CloseableWithCloseFatalException
+    val thrown = the [Exception] thrownBy using (closeable) { c =>
       c.doSomething()
     }
+    thrown.getMessage() shouldEqual ("close")
     thrown.getSuppressed() should have length (0)
+    closeable.n should be (1)
   }
 
   it should "suppress exception when closing fatal exception occurs" in {
-    val thrown = the [InterruptedException] thrownBy using (new CloseableWithExceptionAndCloseFatalException) { c =>
+    val closeable = new CloseableWithExceptionAndCloseFatalException
+    val thrown = the [InterruptedException] thrownBy using (closeable) { c =>
       c.doSomething()
     }
+    thrown.getMessage() shouldEqual ("close")
     thrown.getSuppressed() should have length (1)
+    thrown.getSuppressed()(0).getMessage() shouldEqual ("doSomething")
+    closeable.n should be (1)
   }
 
   it should "suppress closing exception when fatal exception occurs" in {
-    val thrown = the [InterruptedException] thrownBy using (new CloseableWithExceptionAndCloseFatalException) { c =>
+    val closeable = new CloseableWithFatalExceptionAndCloseException
+    val thrown = the [InterruptedException] thrownBy using (closeable) { c =>
       c.doSomething()
     }
+    thrown.getMessage() shouldEqual ("doSomething")
     thrown.getSuppressed() should have length (1)
+    thrown.getSuppressed()(0).getMessage() shouldEqual ("close")
+    closeable.n should be (1)
+  }
+
+  it should "suppress closing fatal exception when fatal exception occurs" in {
+    val closeable = new CloseableWithFatalExceptionAndCloseFatalException
+    val thrown = the [InterruptedException] thrownBy using (closeable) { c =>
+      c.doSomething()
+    }
+    thrown.getMessage() shouldEqual ("doSomething")
+    thrown.getSuppressed() should have length (1)
+    thrown.getSuppressed()(0).getMessage() shouldEqual ("close")
+    closeable.n should be (1)
   }
 
 }
@@ -60,53 +93,81 @@ class TestTryWithResources extends FlatSpec with Matchers {
 object TestTryWithResources {
 
   class Closeable {
-    def close(): Unit = {}
+    var n = 0
+    def close(): Unit = {
+      n += 1
+    }
     def doSomething(): Unit = {}
   }
 
   class CloseableWithException {
-    def close(): Unit = {}
+    var n = 0
+    def close(): Unit = {
+      n += 1
+    }
     def doSomething(): Unit = {
-      throw new Exception
+      throw new Exception("doSomething")
     }
   }
 
   class CloseableWithFatalException {
-    def close(): Unit = {}
+    var n = 0
+    def close(): Unit = {
+      n += 1
+    }
     def doSomething(): Unit = {
-      throw new InterruptedException
+      throw new InterruptedException("doSomething")
     }
   }
 
   class CloseableWithCloseException {
+    var n = 0
     def close(): Unit = {
-      throw new Exception
+      n += 1
+      throw new Exception("close")
     }
     def doSomething(): Unit = {}
   }
 
   class CloseableWithCloseFatalException {
+    var n = 0
     def close(): Unit = {
-      throw new InterruptedException
+      n += 1
+      throw new InterruptedException("close")
     }
     def doSomething(): Unit = {}
   }
 
   class CloseableWithFatalExceptionAndCloseException {
+    var n = 0
     def close(): Unit = {
-      throw new Exception
+      n += 1
+      throw new Exception("close")
     }
     def doSomething(): Unit = {
-      throw new InterruptedException
+      throw new InterruptedException("doSomething")
     }
   }
 
   class CloseableWithExceptionAndCloseFatalException {
+    var n = 0
     def close(): Unit = {
-      throw new InterruptedException
+      n += 1
+      throw new InterruptedException("close")
     }
     def doSomething(): Unit = {
-      throw new Exception
+      throw new Exception("doSomething")
+    }
+  }
+
+  class CloseableWithFatalExceptionAndCloseFatalException {
+    var n = 0
+    def close(): Unit = {
+      n += 1
+      throw new InterruptedException("close")
+    }
+    def doSomething(): Unit = {
+      throw new InterruptedException("doSomething")
     }
   }
 


### PR DESCRIPTION
This PR fixes a bug in our `using` function that tries to close the resource twice over some circumstances.
Thanks @kwalcock for noticing this.